### PR TITLE
Added information on types of objects, which can be used by the `return` statement when later using `runOnSessions` function

### DIFF
--- a/10-ElectroProject.Rmd
+++ b/10-ElectroProject.Rmd
@@ -117,6 +117,7 @@ nCellsSession<-function(rs){
 
 The code is very similar. 
 An important point is to return the results as part of a list.
+(Note that the results cannot be vectors.)
 You can test the function like this.
 
 ```{R epFunction3}
@@ -137,7 +138,7 @@ nCellsSession(rs)
 
 You can also return much more data. 
 For example, you can analyze several spatial properties of neurons and return their firing rate maps.
-In this case, we return an array and a data.frame.
+In this case, we return an array and a data.frame. It is not possible to return vectors.
 
 ```{R epFunction5, cache=TRUE}
 


### PR DESCRIPTION
As far as I can see, it doesn't work to return a `vector` object to the `runOnSessions` function.
Therefore, I added two comments on that in the page for the ElectroProject object.